### PR TITLE
Adding panel

### DIFF
--- a/GWorkspace/Desktop/GWDesktopManager.h
+++ b/GWorkspace/Desktop/GWDesktopManager.h
@@ -36,6 +36,7 @@ typedef enum {
 @class GWorkspace;
 @class GWDesktopView;
 @class Dock;
+@class TopPanel;
 @class MPointWatcher;
 
 @interface GWDesktopManager : NSObject
@@ -61,7 +62,10 @@ typedef enum {
   MPointWatcher *mpointWatcher;
   id ws;
   NSFileManager *fm;
-  NSNotificationCenter *nc;      
+  NSNotificationCenter *nc;
+
+  TopPanel *_topPanel;
+  NSRect _topPanelReservedFrame;      
 }
 
 + (GWDesktopManager *)desktopManager;
@@ -160,6 +164,8 @@ inFileViewerRootedAtPath:(NSString *)rootFullpath;
 - (void)updateDefaults;
 
 - (void)setContextHelp;
+
+- (NSRect)topPanelReservedFrame;
 
 @end
 

--- a/GWorkspace/Desktop/GWDesktopManager.m
+++ b/GWorkspace/Desktop/GWDesktopManager.m
@@ -34,6 +34,7 @@
 #import "GWViewersManager.h"
 #import "TShelf/TShelfWin.h"
 #import "Thumbnailer/GWThumbnailer.h"
+#import "TopPanel/TopPanel.h"
 
 #define RESV_MARGIN 10
 
@@ -115,6 +116,8 @@ static GWDesktopManager *desktopManager = nil;
 
     hidedock = [defaults boolForKey: @"hidedock"];
     dock = [[Dock alloc] initForManager: self];
+
+    _topPanel = [[TopPanel alloc] initForManager:self];
         
     [nc addObserver: self 
            selector: @selector(fileSystemWillChange:) 
@@ -162,6 +165,11 @@ static GWDesktopManager *desktopManager = nil;
   if ((hidedock == NO) && ([dock superview] == nil)) {
     [desktopView addSubview: dock];
     [dock tile];
+  }
+
+  if ([_topPanel superview] == nil) {
+      [desktopView addSubview:_topPanel];
+      [_topPanel tile];
   }
   
   [mpointWatcher startWatching];  
@@ -355,6 +363,11 @@ static GWDesktopManager *desktopManager = nil;
     macmenuReservedFrame.origin.x = 0;
     macmenuReservedFrame.origin.y = screenFrame.size.height - 25;    
   }
+
+  _topPanelReservedFrame = NSMakeRect(0,
+      screenFrame.size.height - 30,  // top
+      screenFrame.size.width,
+      30);
 
   dockReservedFrame.size.height = screenFrame.size.height;
   dockReservedFrame.size.width = 64 + RESV_MARGIN;
@@ -651,6 +664,10 @@ inFileViewerRootedAtPath:(NSString *)rootFullpath
   help = @"Recycler.rtfd";
   [manager setContextHelp: (NSAttributedString *)help 
                withObject: [dock trashIcon]];
+}
+
+- (NSRect)topPanelReservedFrame {
+    return _topPanelReservedFrame;
 }
 
 @end

--- a/GWorkspace/Desktop/GWDesktopView.m
+++ b/GWorkspace/Desktop/GWDesktopView.m
@@ -427,6 +427,7 @@
   gridrect.size.height -= tshfr.size.height;
   gridrect.size.width -= dckr.size.width;
   gridrect.size.height -= mmfr.size.height;
+  gridrect.size.height -= [manager topPanelReservedFrame].size.height;
 
   if ([manager dockPosition] == DockPositionLeft)
     {

--- a/GWorkspace/Desktop/TopPanel/TopPanel.h
+++ b/GWorkspace/Desktop/TopPanel/TopPanel.h
@@ -1,0 +1,11 @@
+#import <AppKit/AppKit.h>
+
+@class GWDesktopManager;
+
+@interface TopPanel : NSView
+{
+    GWDesktopManager *_manager;
+}
+- (instancetype)initForManager:(GWDesktopManager *)manager;
+- (void)tile;
+@end

--- a/GWorkspace/Desktop/TopPanel/TopPanel.m
+++ b/GWorkspace/Desktop/TopPanel/TopPanel.m
@@ -1,0 +1,28 @@
+#import "TopPanel.h"
+#import "GWDesktopManager.h"
+
+@implementation TopPanel
+
+- (instancetype)initForManager:(GWDesktopManager *)manager {
+    self = [super initWithFrame:NSMakeRect(0, 0, 100, 30)];
+    if (self) {
+        _manager = manager;
+        [self setAutoresizingMask:NSViewWidthSizable];
+        [self setNeedsDisplay:YES];
+    }
+    return self;
+}
+
+- (void)drawRect:(NSRect)rect {
+    [[NSColor controlBackgroundColor] set];
+    NSRectFill(rect);
+}
+
+- (void)tile {
+    NSRect screen = [[NSScreen mainScreen] frame];
+    CGFloat height = 30.0;
+    [self setFrame:NSMakeRect(0, screen.size.height - height, screen.size.width, height)];
+    [self setNeedsDisplay:YES];
+}
+
+@end

--- a/GWorkspace/Desktop/TopPanel/TopPanel.m
+++ b/GWorkspace/Desktop/TopPanel/TopPanel.m
@@ -4,7 +4,7 @@
 @implementation TopPanel
 
 - (instancetype)initForManager:(GWDesktopManager *)manager {
-    self = [super initWithFrame:NSMakeRect(0, 0, 100, 30)];
+    self = [super initWithFrame:NSMakeRect(0, 0, 100, 28)];
     if (self) {
         _manager = manager;
         [self setAutoresizingMask:NSViewWidthSizable];
@@ -20,7 +20,7 @@
 
 - (void)tile {
     NSRect screen = [[NSScreen mainScreen] frame];
-    CGFloat height = 30.0;
+    CGFloat height = 28.0;
     [self setFrame:NSMakeRect(0, screen.size.height - height, screen.size.width, height)];
     [self setNeedsDisplay:YES];
 }

--- a/GWorkspace/GNUmakefile.in
+++ b/GWorkspace/GNUmakefile.in
@@ -73,6 +73,7 @@ Desktop/GWDesktopView.m \
 Desktop/GWDesktopIcon.m \
 Desktop/Dock/Dock.m \
 Desktop/Dock/DockIcon.m \
+Desktop/TopPanel/TopPanel.m \
 FileViewer/GWViewersManager.m \
 FileViewer/GWViewer.m \
 FileViewer/GWViewerWindow.m \


### PR DESCRIPTION
* Ensures that GNUstep apps never consume the top of screen
* Resolves flashing menu problems when GNUstep is used without an external panel such as XFCE, or MATE